### PR TITLE
Fix sandbox runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,24 +13,6 @@ RUN apt-get update \
     && wget -O - https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz | tar xzf - -C /usr/local/bin \
     && apt-get autoremove -yqq --purge wget && rm -rf /var/lib/apt/lists/*
 
-# ------------- Dockerクライアントのみのインストール ---------------------------------
-# 参考: https://docs.docker.com/engine/install/debian/#install-using-the-repository
-# Add Docker's official GPG key:
-RUN apt-get update && \
-    apt-get install ca-certificates curl -y && \
-    install -m 0755 -d /etc/apt/keyrings && \
-    curl -4fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc && \
-    chmod a+r /etc/apt/keyrings/docker.asc
-  
-# Add the repository to Apt sources:
-RUN echo \
-    "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian \
-    $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
-    tee /etc/apt/sources.list.d/docker.list > /dev/null
-RUN apt-get update
-RUN apt-get install docker-ce-cli -y
-# ------------------------------------------------------------------------------
-
 # 必要なPythonライブラリのインストール
 # (pyproject.tomlからryeによって自動生成されたrequirements.lockを使用)
 # 参考: https://rye.astral.sh/guide/docker/

--- a/langs/Dockerfile.GCC
+++ b/langs/Dockerfile.GCC
@@ -4,6 +4,13 @@ RUN apt-get update; \
     apt-get install -y --no-install-recommends gcc make libc6-dev; \
     rm -rf /var/lib/apt/lists/*
 
+# watchdogをコピー
+# uid:gid=root:rootで、ファイルのパーミッションは700にする
+COPY watchdog /home/guest/watchdog
+RUN chown root:root /home/guest/watchdog
+RUN chmod 700 /home/guest/watchdog
+
+# ゲストユーザー(1000:1000)のホームディレクトリを作成
 RUN mkdir -p /home/guest
 RUN chown -R 1000:1000 /home/guest
 RUN chmod -R 755 /home/guest

--- a/langs/Dockerfile.binary-runner
+++ b/langs/Dockerfile.binary-runner
@@ -1,8 +1,10 @@
 FROM ubuntu:24.10
 
 # 出力をソート・整形するためのperlライブラリのインストール
+# メモリリーク検出のためのvalgrindのインストール
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libperl5.38 \
+    valgrind \
     && rm -rf /var/lib/apt/lists/*
 
 # watchdogをコピー

--- a/langs/Dockerfile.binary-runner
+++ b/langs/Dockerfile.binary-runner
@@ -5,6 +5,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libperl5.38 \
     && rm -rf /var/lib/apt/lists/*
 
+# watchdogをコピー
+# uid:gid=root:rootで、ファイルのパーミッションは700にする
+COPY watchdog /home/guest/watchdog
+RUN chown root:root /home/guest/watchdog
+RUN chmod 700 /home/guest/watchdog
+
+# ゲストユーザー(1000:1000)のホームディレクトリを作成
 RUN mkdir -p /home/guest
 RUN chown -R 1000:1000 /home/guest
 RUN chmod -R 755 /home/guest

--- a/langs/Dockerfile.builder
+++ b/langs/Dockerfile.builder
@@ -1,0 +1,3 @@
+FROM ubuntu:24.10
+
+RUN apt update && apt install -y gcc g++ nlohmann-json3-dev

--- a/langs/build.sh
+++ b/langs/build.sh
@@ -4,6 +4,13 @@ set -e
 
 SCRIPT_DIR=$(cd $(dirname $0); pwd)
 
+# builderイメージをビルド
+docker build -t builder-watchdog -f $SCRIPT_DIR/Dockerfile.builder $SCRIPT_DIR
+
+# watchdog.cppのコンパイル
+docker run --rm -it -v $SCRIPT_DIR:/work --workdir /work builder-watchdog \
+  bash -c "g++ -o watchdog watchdog.cpp"
+
 # GCCを使えるsandboxイメージをビルド
 docker build -t checker-lang-gcc -f $SCRIPT_DIR/Dockerfile.GCC $SCRIPT_DIR
 

--- a/langs/watchdog.cpp
+++ b/langs/watchdog.cpp
@@ -11,6 +11,8 @@
 #include <unistd.h>
 #include <sys/resource.h>
 #include <sstream>
+#include <vector>
+#include <string>
 
 using json = nlohmann::json;
 
@@ -40,6 +42,42 @@ json readFromFile(const std::string& filename) {
   return json::parse(jsonString);
 }
 
+std::vector<pid_t> get_child_pids(pid_t parent_pid) {
+  std::vector<pid_t> children;
+  std::string cmd = std::string("pgrep -P ") + std::to_string(parent_pid);
+
+  // コマンドを実行
+  FILE* stream = popen(cmd.c_str(), "r");
+  if (!stream) {
+    throw std::runtime_error("popen failed");
+  }
+
+  char buffer[128];
+  while (fgets(buffer, sizeof(buffer), stream) != nullptr) {
+    pid_t pid = std::stoi(std::string(buffer));
+    children.push_back(pid);
+  }
+
+  pclose(stream);
+  return children;
+}
+
+void kill_recursive(pid_t pid) {
+  try {
+    // まず子プロセスを終了
+    std::vector<pid_t> children = get_child_pids(pid);
+    for (pid_t child : children) {
+      kill_recursive(child);
+    }
+
+    // 対象プロセスを終了
+    if (kill(pid, SIGKILL) < 0) {
+      std::cerr << "Failed to kill process " << pid << std::endl;
+    }
+  } catch (const std::exception& e) {
+    std::cerr << "Error in kill_recursive: " << e.what() << std::endl;
+  }
+}
 
 int main(int argc, char** argv) {
   json jsonData;
@@ -76,6 +114,14 @@ int main(int argc, char** argv) {
   } catch (const json::out_of_range& e) {
     std::printf("Key not found: %s\n", e.what());
     exit(1);
+  }
+
+  std::vector<std::string> args;
+  // commandを空白で分割
+  std::string token;
+  std::istringstream token_stream(command);
+  while (token_stream >> token) {
+    args.push_back(token);
   }
 
   int exit_code = -1;
@@ -144,16 +190,24 @@ int main(int argc, char** argv) {
         ptr += written;
       }
       close(stdin_pipe[1]);
+      // printf("stdin child finished\n");
       exit(0);
     } else {
       // 子プロセスの標準入力を設定
       close(stdin_pipe[1]);
+      close(STDIN_FILENO);
       dup2(stdin_pipe[0], STDIN_FILENO);
       close(stdin_pipe[0]);
 
+      char** argv = new char*[args.size() + 1];
+      for (size_t i = 0; i < args.size(); i++) {
+        argv[i] = const_cast<char*>(args[i].c_str());
+      }
+      argv[args.size()] = NULL;
+
       // コマンドを実行
-      execl("/bin/sh", "sh", "-c", command.c_str(), NULL);
-      std::perror("execl failed");
+      execvp(argv[0], argv);
+      std::perror("execvp failed");
       exit(1);
     }
   } else {
@@ -167,11 +221,16 @@ int main(int argc, char** argv) {
 
     // タイムアウト用のタイマースレッド
     std::thread timeout_thread([&]() {
-      while (!finished.load()) { 
+      while (!finished.load()) {
         auto now = std::chrono::steady_clock::now();
-        if (std::chrono::duration_cast<std::chrono::seconds>(now - start_time).count() >= timeoutSec) {
+        // printf("%ldms elapsed, finished: %d\n", std::chrono::duration_cast<std::chrono::milliseconds>(now - start_time).count(), finished.load());
+        if (std::chrono::duration_cast<std::chrono::milliseconds>(now - start_time).count() >= timeoutSec * 1000) {
           // タイムアウト
-          kill(pid, SIGKILL);
+          // printf("timeout, kill %d\n", pid);
+          // shで実行している場合、子プロセスが残っているため、再帰的に終了する必要がある。
+          // そうしないと、子プロセスが実行され続けてしまうし、stdoutやstderrがパイプにEOFが送られない。
+          kill_recursive(pid);
+          // printf("waitpid: %d\n", waitpid(pid, NULL, 0));
           break;
         }
         std::this_thread::sleep_for(std::chrono::milliseconds(50));
@@ -195,7 +254,7 @@ int main(int argc, char** argv) {
 
         if (current_memory > static_cast<int64_t>(memoryLimitMB) * 1024 * 1024) {
           // メモリ制限超過
-          kill(pid, SIGKILL);
+          kill_recursive(pid);
           break;
         }
 
@@ -209,11 +268,13 @@ int main(int argc, char** argv) {
     waitpid(pid, &status, 0);
     finished.store(true);
     monitor_thread.join();
+    // printf("monitor thread finished\n");
     // 実行時間を計算
     auto end_time = std::chrono::steady_clock::now();
     timeMS = std::chrono::duration_cast<std::chrono::milliseconds>(end_time - start_time).count();
 
     timeout_thread.join();
+    // printf("timeout thread finished\n");
 
     // 最大メモリ使用量 (KB)
     memoryKB = static_cast<int>(max_memory) / 1024;
@@ -227,12 +288,14 @@ int main(int argc, char** argv) {
       stdout_stream.write(buffer, count);
     }
     stdout_str = stdout_stream.str();
+    // printf("stdout: %s\n", stdout_str.c_str());
 
     std::ostringstream stderr_stream;
     while ((count = read(stderr_pipe[0], buffer, sizeof(buffer))) > 0) {
       stderr_stream.write(buffer, count);
     }
     stderr_str = stderr_stream.str();
+    // printf("stderr: %s\n", stderr_str.c_str());
 
     close(stdout_pipe[0]);
     close(stderr_pipe[0]);

--- a/langs/watchdog.cpp
+++ b/langs/watchdog.cpp
@@ -92,7 +92,7 @@ int main(int argc, char** argv) {
    * {
    *   "command": "cmd [args...]",
    *   "stdin": "stdin data",
-   *   "timeoutSec": 3,
+   *   "timeoutMS": 3000,
    *   "memoryLimitMB": 1024,
    *   "uid": 1000,
    *   "gid": 1000
@@ -100,14 +100,14 @@ int main(int argc, char** argv) {
    */
   std::string command;
   std::string stdin;
-  int timeoutSec = 0;
+  int timeoutMS = 0;
   int memoryLimitMB = 0;
   int uid = 0;
   int gid = 0;
   try {
     command = jsonData.at("command");
     stdin = jsonData.at("stdin");
-    timeoutSec = jsonData.at("timeoutSec");
+    timeoutMS = jsonData.at("timeoutMS");
     memoryLimitMB = jsonData.at("memoryLimitMB");
     uid = jsonData.at("uid");
     gid = jsonData.at("gid");
@@ -224,7 +224,7 @@ int main(int argc, char** argv) {
       while (!finished.load()) {
         auto now = std::chrono::steady_clock::now();
         // printf("%ldms elapsed, finished: %d\n", std::chrono::duration_cast<std::chrono::milliseconds>(now - start_time).count(), finished.load());
-        if (std::chrono::duration_cast<std::chrono::milliseconds>(now - start_time).count() >= timeoutSec * 1000) {
+        if (std::chrono::duration_cast<std::chrono::milliseconds>(now - start_time).count() >= timeoutMS) {
           // タイムアウト
           // printf("timeout, kill %d\n", pid);
           // shで実行している場合、子プロセスが残っているため、再帰的に終了する必要がある。
@@ -315,7 +315,7 @@ int main(int argc, char** argv) {
     result["stderr"] = stderr_str;
     result["timeMS"] = timeMS;
     result["memoryKB"] = memoryKB;
-    result["TLE"] = timeoutSec > 0 && timeMS >= timeoutSec * 1000;
+    result["TLE"] = timeoutMS > 0 && timeMS >= timeoutMS;
     result["MLE"] = memoryLimitMB > 0 && memoryKB / 1024 >= memoryLimitMB;
     std::cout << result.dump(4) << std::endl;
   }

--- a/langs/watchdog.cpp
+++ b/langs/watchdog.cpp
@@ -1,0 +1,255 @@
+#include <nlohmann/json.hpp>
+#include <iostream>
+#include <chrono>
+#include <thread>
+#include <fstream>
+#include <atomic>
+#include <sys/wait.h>
+#include <sys/types.h>
+#include <signal.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/resource.h>
+#include <sstream>
+
+using json = nlohmann::json;
+
+json readFromStdin() {
+  std::string line;
+  std::string jsonString;
+
+  while (std::getline(std::cin, line)) {
+    jsonString += line;
+  }
+
+  try {
+    return json::parse(jsonString);
+  } catch (const json::parse_error& e) {
+    std::printf("Error parsing input JSON: %s\n", e.what());
+    exit(1);
+  }
+}
+
+json readFromFile(const std::string& filename) {
+  std::ifstream file(filename);
+  std::string jsonString((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
+  return json::parse(jsonString);
+}
+
+
+int main(int argc, char** argv) {
+  json jsonData;
+  if (argc == 2) {
+    jsonData = readFromFile(argv[1]);
+  } else {
+    jsonData = readFromStdin();
+  }
+
+  /**
+   * JSONデータは以下のような形式になっている
+   * {
+   *   "command": "cmd [args...]",
+   *   "stdin": "stdin data",
+   *   "timeoutSec": 3,
+   *   "memoryLimitMB": 1024,
+   *   "uid": 1000,
+   *   "gid": 1000
+   * }
+   */
+  std::string command;
+  std::string stdin;
+  int timeoutSec = 0;
+  int memoryLimitMB = 0;
+  int uid = 0;
+  int gid = 0;
+  try {
+    command = jsonData.at("command");
+    stdin = jsonData.at("stdin");
+    timeoutSec = jsonData.at("timeoutSec");
+    memoryLimitMB = jsonData.at("memoryLimitMB");
+    uid = jsonData.at("uid");
+    gid = jsonData.at("gid");
+  } catch (const json::out_of_range& e) {
+    std::printf("Key not found: %s\n", e.what());
+    exit(1);
+  }
+
+  int exit_code = -1;
+  std::string stdout_str;
+  std::string stderr_str;
+  int timeMS = 0;
+  int memoryKB = 0;
+
+  int stdout_pipe[2];
+  int stderr_pipe[2];
+
+  if (pipe(stdout_pipe) == -1 || pipe(stderr_pipe) == -1) {
+    std::perror("pipe failed");
+    exit(1);
+  }
+
+  pid_t pid = fork();
+  if (pid == -1) {
+    // フォーク失敗
+    std::perror("fork failed");
+    exit(1);
+  } else if (pid == 0) {
+    // 子プロセス
+    // 標準出力と標準エラーをパイプにリダイレクト
+    close(STDOUT_FILENO);
+    close(STDERR_FILENO);
+    dup2(stdout_pipe[1], STDOUT_FILENO);
+    dup2(stderr_pipe[1], STDERR_FILENO);
+    close(stdout_pipe[0]);
+    close(stderr_pipe[0]);
+    close(stdout_pipe[1]);
+    close(stderr_pipe[1]);
+
+    // プロセス権限の変更
+    if (setgid(gid) != 0) {
+      std::perror("setgid failed");
+      exit(1);
+    }
+    if (setuid(uid) != 0) {
+      std::perror("setuid failed");
+      exit(1);
+    }
+
+    // 標準入力を設定 
+    int stdin_pipe[2];
+    if (pipe(stdin_pipe) == -1) {
+      std::perror("stdin pipe failed");
+      exit(1);
+    }
+    pid_t stdin_pid = fork();
+    if (stdin_pid == -1) {
+      std::perror("stdin fork failed");
+      exit(1);
+    } else if (stdin_pid == 0) {
+      // stdinデータを書き込む
+      close(stdin_pipe[0]);
+      int remaining = stdin.size();
+      const char* ptr = stdin.c_str();
+      while (remaining > 0) {
+        int written = write(stdin_pipe[1], ptr, remaining);
+        if (written <= 0) {
+          std::perror("write to stdin pipe failed");
+          exit(1);
+        }
+        remaining -= written;
+        ptr += written;
+      }
+      close(stdin_pipe[1]);
+      exit(0);
+    } else {
+      // 子プロセスの標準入力を設定
+      close(stdin_pipe[1]);
+      dup2(stdin_pipe[0], STDIN_FILENO);
+      close(stdin_pipe[0]);
+
+      // コマンドを実行
+      execl("/bin/sh", "sh", "-c", command.c_str(), NULL);
+      std::perror("execl failed");
+      exit(1);
+    }
+  } else {
+    // 親プロセス
+    close(stdout_pipe[1]);
+    close(stderr_pipe[1]);
+
+    auto start_time = std::chrono::steady_clock::now();
+    std::atomic<bool> finished(false);
+    int64_t max_memory = 0;
+
+    // タイムアウト用のタイマースレッド
+    std::thread timeout_thread([&]() {
+      while (!finished.load()) { 
+        auto now = std::chrono::steady_clock::now();
+        if (std::chrono::duration_cast<std::chrono::seconds>(now - start_time).count() >= timeoutSec) {
+          // タイムアウト
+          kill(pid, SIGKILL);
+          break;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+      }
+    });
+
+    // リソース監視スレッド
+    std::thread monitor_thread([&]() {
+      std::ifstream mem_file("/sys/fs/cgroup/memory.current");
+      while (!finished.load()) {
+        // メモリ使用量を取得
+        int64_t current_memory;
+        if (mem_file.is_open()) {
+          mem_file >> current_memory;
+          mem_file.seekg(0);
+        }
+
+        if (current_memory > max_memory) {
+          max_memory = current_memory;
+        }
+
+        if (current_memory > static_cast<int64_t>(memoryLimitMB) * 1024 * 1024) {
+          // メモリ制限超過
+          kill(pid, SIGKILL);
+          break;
+        }
+
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+      }
+      mem_file.close();
+    });
+
+    // 子プロセスの終了を待つ
+    int status;
+    waitpid(pid, &status, 0);
+    finished.store(true);
+    monitor_thread.join();
+    // 実行時間を計算
+    auto end_time = std::chrono::steady_clock::now();
+    timeMS = std::chrono::duration_cast<std::chrono::milliseconds>(end_time - start_time).count();
+
+    timeout_thread.join();
+
+    // 最大メモリ使用量 (KB)
+    memoryKB = static_cast<int>(max_memory) / 1024;
+
+
+    // 標準衆力と標準エラー出力を取得)
+    char buffer[4096];
+    ssize_t count;
+    std::ostringstream stdout_stream;
+    while ((count = read(stdout_pipe[0], buffer, sizeof(buffer))) > 0) {
+      stdout_stream.write(buffer, count);
+    }
+    stdout_str = stdout_stream.str();
+
+    std::ostringstream stderr_stream;
+    while ((count = read(stderr_pipe[0], buffer, sizeof(buffer))) > 0) {
+      stderr_stream.write(buffer, count);
+    }
+    stderr_str = stderr_stream.str();
+
+    close(stdout_pipe[0]);
+    close(stderr_pipe[0]);
+
+    if (WIFEXITED(status)) {
+      exit_code = WEXITSTATUS(status);
+    } else if (WIFSIGNALED(status)) {
+      exit_code = 128 + WTERMSIG(status);
+    } else {
+      exit_code = -1;
+    }
+
+    // 結果をJSONで出力
+    json result;
+    result["exit_code"] = exit_code;
+    result["stdout"] = stdout_str;
+    result["stderr"] = stderr_str;
+    result["timeMS"] = timeMS;
+    result["memoryKB"] = memoryKB;
+    result["TLE"] = timeoutSec > 0 && timeMS >= timeoutSec * 1000;
+    result["MLE"] = memoryLimitMB > 0 && memoryKB / 1024 >= memoryLimitMB;
+    std::cout << result.dump(4) << std::endl;
+  }
+}

--- a/langs/watchdog.cpp
+++ b/langs/watchdog.cpp
@@ -32,6 +32,10 @@ json readFromStdin() {
 
 json readFromFile(const std::string& filename) {
   std::ifstream file(filename);
+  if (!file.is_open()) {
+    std::perror("Failed to open file");
+    exit(1);
+  }
   std::string jsonString((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
   return json::parse(jsonString);
 }

--- a/src/checker.py
+++ b/src/checker.py
@@ -21,7 +21,7 @@ class StandardChecker:
         ls_lines = [line for line in ls_lines if line != '']
         rs_lines = [line for line in rs_lines if line != '']
                 
-        # print(f"ls: {ls_lines}, rs: {rs_lines}")
+        # logger.info(f"ls: {ls_lines}, rs: {rs_lines}")
 
         # 行数が異なる場合はFalse
         if len(ls_lines) != len(rs_lines):
@@ -45,7 +45,7 @@ class StandardChecker:
         ls_lines = [line.split() for line in ls_lines]
         rs_lines = [line.split() for line in rs_lines]
         
-        print(f"ls_lines: {ls_lines}, rs_lines: {rs_lines}")
+        # logger.info(f"ls_lines: {ls_lines}, rs_lines: {rs_lines}")
         
         # 各行を比較
         for ls_line, rs_line in zip(ls_lines, rs_lines):

--- a/src/sandbox/execute.py
+++ b/src/sandbox/execute.py
@@ -13,9 +13,7 @@ import threading
 from pydantic import BaseModel, Field
 from dataclasses import dataclass, field
 import time  # 実行時間の計測に使用
-import re
 from pathlib import Path
-from typing import Callable
 import logging
 import docker
 from docker.models.containers import Container
@@ -56,23 +54,6 @@ class DockerVolume:
     @classmethod
     def create(cls, client: docker.DockerClient) -> tuple["DockerVolume", Error]:
         volumeName = "volume-" + str(uuid.uuid4())
-
-
-        args = ["volume", "create"]
-        args += ["--name", volumeName]
-
-        # Dockerボリュームの作成
-        cmd = ["docker"] + args
-        err = ""
-
-        
-        args = ["volume", "create"]
-        args += ["--name", volumeName]
-
-        # Dockerボリュームの作成
-        cmd = ["docker"] + args
-        err = ""
-
         try:
             volume = client.volumes.create(name=volumeName)
         except APIError as e:
@@ -92,134 +73,6 @@ class DockerVolume:
 
         return Error("")
 
-    def copyFile(self, client: docker.DockerClient, srcPathOnClient: Path, dstDirOnVolume: Path = Path("./")) -> Error:
-        try:
-            container: Container = client.containers.create(
-                image="binary-runner",
-                command=["echo", "Hello, World!"],
-                working_dir="/home/guest",
-                user=f"{GUEST_UID}:{GUEST_GID}",
-                volumes={self._volume.name: {'bind': '/home/guest', 'mode': 'rw'}}
-            )
-        
-            # filePathInVolumeが絶対パスの場合、相対パスに変換
-            if dstDirOnVolume.is_absolute():
-                dstDirOnVolume = Path(".") / dstDirOnVolume.relative_to("/")
-
-            dstInContainer = Path("/home/guest") / dstDirOnVolume / srcPathOnClient.name
-            # docker sdkのput_archiveは停止しているコンテナには使えない
-            # そのため、docker cpコマンドを使ってファイルをコピーする
-            cmd = ["docker", "cp", str(srcPathOnClient), f"{container.id}:{str(dstInContainer)}"]
-            SANDBOX_LOGGER.debug(f"cmd: {cmd}")
-            if subprocess.run(cmd, check=False).returncode != 0:
-                return Error(f"Failed to copy file")
-    
-            container.remove()
-        except APIError as e:
-            return Error(f"Failed to copy file: {e}")
-        except ImageNotFound as e:
-            return Error(f"Failed to copy file: {e}")
-        except Exception as e:
-            return Error(f"Failed to copy file: {e}")
-        return Error("")
-
-    def copyFiles(
-        self, client: docker.DockerClient, srcPathsOnClient: list[Path], dstDirOnVolume: Path = Path("./")
-    ) -> Error:
-        try:
-            container: Container = client.containers.create(
-                image="binary-runner",
-                command=["echo", "Hello, World!"],
-                working_dir="/home/guest",
-                user=f"{GUEST_UID}:{GUEST_GID}",
-                volumes={self._volume.name: {'bind': '/home/guest', 'mode': 'rw'}}
-            )
-            
-            # DirPathInVolumeが絶対パスの場合、相対パスに変換
-            if dstDirOnVolume.is_absolute():
-                dstDirOnVolume = Path(".") / dstDirOnVolume.relative_to("/")
-
-            for srcPathOnClient in srcPathsOnClient:
-                dstPathInContainer = Path("/home/guest") / dstDirOnVolume / srcPathOnClient.name
-                cmd = ["docker", "cp", str(srcPathOnClient), f"{container.id}:{str(dstPathInContainer)}"]
-                SANDBOX_LOGGER.debug(f"cmd: {cmd}")
-                if subprocess.run(cmd, check=False).returncode != 0:
-                    return Error(f"Failed to copy file")
-            
-            container.remove(force=True)
-        except APIError as e:
-            return Error(f"Failed to copy file: {e}")
-        except ImageNotFound as e:
-            return Error(f"Failed to copy file: {e}")
-        except Exception as e:
-            return Error(f"Failed to copy file: {e}")
-
-        return Error("")
-
-    def removeFiles(self, client: docker.DockerClient, filePathsInVolume: list[Path]) -> Error:
-        arguments = ["rm"]
-
-        for filePath in filePathsInVolume:
-            if filePath.is_absolute():
-                filePath = Path(".") / filePath.relative_to("/")
-            filePathInContainer = Path("/home/guest") / filePath
-            arguments += [str(filePathInContainer.resolve())]
-            
-        try:
-            container: Container = client.containers.create(
-                image="binary-runner",
-                command=arguments,
-                working_dir="/home/guest",
-                user=f"{GUEST_UID}:{GUEST_GID}",
-                volumes={self._volume.name: {'bind': '/home/guest', 'mode': 'rw'}}
-            )
-            
-            container.start()
-            container.wait()
-            container.remove(force=True)
-        except APIError as e:
-            return Error(f"Failed to remove file: {e}")
-        except ImageNotFound as e:
-            return Error(f"Failed to remove file: {e}")
-        except Exception as e:
-            return Error(f"Failed to remove file: {e}")
-
-        return Error("")
-    
-    def clone(self, client: docker.DockerClient) -> tuple["DockerVolume", Error]:
-        # 新しいDockerボリュームを作成
-        new_volume, err = DockerVolume.create(client)
-        if err.message != "":
-            return DockerVolume("", None), Error(f"新しいボリュームの作成に失敗しました: {err.message}")
-
-        # 元のボリュームの内容を新しいボリュームにコピー
-        try:
-            container: Container = client.containers.create(
-                image="binary-runner",
-                command=["cp", "-r", "/workdir/src/.", "/workdir/dst"],
-                working_dir="/workdir",
-                user="root",
-                volumes={self._volume.name: {'bind': '/workdir/src', 'mode': 'rw'}, new_volume.name: {'bind': '/workdir/dst', 'mode': 'rw'}}
-            )
-            
-            container.start()
-            result = container.wait()
-
-            if result["StatusCode"] != 0:
-                new_volume.remove()
-                return DockerVolume("", None), Error(f"Failed to clone volume")
-            
-            container.remove(force=True)
-        except APIError as e:
-            return DockerVolume("", None), Error(f"Failed to clone volume: {e}")
-        except ImageNotFound as e:
-            return DockerVolume("", None), Error(f"Failed to clone volume: {e}")
-        except Exception as e:
-            return DockerVolume("", None), Error(f"Failed to clone volume: {e}")
-
-        return new_volume, Error("")
-
-
 class VolumeMountInfo:
     path: str # コンテナ内のマウント先のパス
     volume: DockerVolume  # マウントするボリュームの情報
@@ -237,18 +90,13 @@ class ContainerInfo:
     _container: Container | None
     cgroup_parent: str
     
-    def __init__(self):
-        self._container = None
-        self.containerID = ""
-        self.cgroup_parent = ""
-
-    # Dockerコンテナの作成
-    def _create(
+    def __init__(
         self,
         client: docker.DockerClient,
         ImageName: str,
         arguments: list[str],
-        cgroupParent: str | None = CGROUP_PARENT,
+        interactive: bool = False,
+        cgroupParent: str | None = None,
         user: str | None = f"{GUEST_UID}",
         groups: list[str] | None = [f"{GUEST_GID}"],
         cpuset: list[int] | None = None,
@@ -258,53 +106,41 @@ class ContainerInfo:
         enableNetwork: bool = False,
         enableLoggingDriver: bool = True,
         workDir: str = "/home/guest",
-        volumeMountInfoList: list[VolumeMountInfo] = None,
-    ) -> Error:
-        
-        SANDBOX_LOGGER.info(f"cgroupParent: {cgroupParent}")
-        
+        volumeMountInfoList: list[VolumeMountInfo] | None = None,
+    ):
         ulimit_list: list[Ulimit] = []
         
         if stackLimitKB > 0:
             ulimit_list += [Ulimit(name="stack", soft=stackLimitKB, hard=stackLimitKB)]
         
-        try:
-            container: Container = client.containers.create(
-                image=ImageName,
-                command=arguments,
-                cgroup_parent = cgroupParent if cgroupParent is not None else "system.slice",
-                user=user,
-                group_add=groups,
-                cpuset_cpus=",".join([str(cpu) for cpu in cpuset]) if cpuset is not None else None,
-                mem_limit=f"{memoryLimitMB}m" if memoryLimitMB > 0 else None,
-                memswap_limit=f"{memoryLimitMB}m" if memoryLimitMB > 0 else None,
-                ulimits=ulimit_list,
-                pids_limit=pidsLimit if pidsLimit > 0 else None,
-                network_disabled=not enableNetwork,
-                log_config=LogConfig(type=LogConfig.types.JSON) if enableLoggingDriver else None,
-                working_dir=workDir,
-                volumes={
-                    volume_mount_info.volume.name: {
-                        "bind": volume_mount_info.path,
-                        "mode": "rw" if not volume_mount_info.read_only else "ro"
-                    } for volume_mount_info in volumeMountInfoList  
-                },
-                stdin_open=True, # Keep STDIN open even if not attached (-iオプションに相当)
-            )
-            
-            self._container = container
-            self.containerID = container.id
-            self.cgroup_parent = cgroupParent if cgroupParent is not None else "system.slice"
-        except APIError as e:
-            return Error(f"Failed to create container: {e}")
-        except ImageNotFound as e:
-            return Error(f"Failed to create container: {e}")
-        except Exception as e:
-            return Error(f"Failed to create container: {e}")
+        container: Container = client.containers.create(
+            image=ImageName,
+            command=arguments,
+            cgroup_parent=cgroupParent if cgroupParent is not None else None,
+            user=user,
+            group_add=groups,
+            cpuset_cpus=",".join([str(cpu) for cpu in cpuset]) if cpuset is not None else None,
+            mem_limit=f"{memoryLimitMB}m" if memoryLimitMB > 0 else None,
+            memswap_limit=f"{memoryLimitMB}m" if memoryLimitMB > 0 else None,
+            ulimits=ulimit_list,
+            pids_limit=pidsLimit if pidsLimit > 0 else None,
+            network_disabled=not enableNetwork,
+            log_config=LogConfig(type=LogConfig.types.JSON) if enableLoggingDriver else None,
+            working_dir=workDir,
+            volumes={
+                volume_mount_info.volume.name: {
+                    "bind": volume_mount_info.path,
+                    "mode": "rw" if not volume_mount_info.read_only else "ro"
+                } for volume_mount_info in volumeMountInfoList  
+            },
+            stdin_open=interactive,
+        )
+        
+        self._container = container
+        self.containerID = container.id
+        self.cgroup_parent = cgroupParent if cgroupParent is not None else "system.slice"
         
         SANDBOX_LOGGER.debug(f'containerID: {self.containerID}, err: ""')
-
-        return Error("")
 
     def remove(self) -> Error:
         try:
@@ -340,335 +176,95 @@ class ContainerInfo:
         SANDBOX_LOGGER.debug(f"copy file: {srcInHost} -> {dstInContainer}")
 
         return Error("")
+    
+    def start(self) -> Error:
+        try:
+            self._container.start()
+        except APIError as e:
+            return Error(f"Failed to start container: {e}")
+        except Exception as e:
+            return Error(f"Failed to start container: {e}")
 
+        SANDBOX_LOGGER.debug(f"start container: {self.containerID}")
 
-__MEM_USAGE_PATTERN = re.compile(r"^(\d+(\.\d+)?)([KMG]i?)B")
+        return Error("")
 
-
-# 時間・メモリ計測用のモニター
-class TaskMonitor:
-    cgroup_parent: str
-    _cgroup_path: Path
-    startTime: int
-    endTime: int
-    maxUsedMemory: int  # 最大使用メモリ量[Byte]
-    containerInfo: ContainerInfo  # モニタリング対象のコンテナ情報
-    _monitoring: bool  # モニタリング中かどうか
-    _monitor_thread: threading.Thread  # モニタリングスレッド
-
-    def __init__(self, containerInfo: ContainerInfo):
-        self.cgroup_parent = containerInfo.cgroup_parent
-        self.startTime = 0
-        self.endTime = 0
-        self.maxUsedMemory = 0
-        self.containerInfo = containerInfo
-        self._monitoring = False
-        self._cgroup_path = Path("/sys-host/fs/cgroup/") / self.cgroup_parent / f"docker-{containerInfo.containerID}.scope" / "memory.current"
-
-    def start(self):
-        self.startTime = time.time_ns()
-        # containerInfo.containerIDを使ってコンテナのメモリ使用量を取得する
-        # 取得はdocker statsコマンドを使い、1msごとに取得する
-        # 取得したメモリ使用量からmaxUsedMemoryを更新する
-        self._monitoring = True
-        # TODO: docker statsは遅いので、/sys/fs/cgroupからメモリ使用量を取得する方法を検討する
-        self._monitor_thread = threading.Thread(
-            target=self.__monitor_memory_usage_by_cgroup
-        )
-        self._monitor_thread.start()
-
-    def end(self):
-        self.endTime = time.time_ns()
-        self._monitoring = False
-        self._monitor_thread.join()
-
-    def get_elapsed_time_ms(self) -> float:
-        return (self.endTime - self.startTime) / 1e6
-
-    def get_used_memory_byte(self) -> int:
-        return self.maxUsedMemory
-
-    '''
-    Dockerコンテナのメモリの取得方法は3つある
-    1. docker statsコマンドを使って取得する
-    2. /sys/fs/cgroup/system.slice/docker-xxxxxx.scope/memory.currentから取得する
-    3. psコマんドで取得する
-         * docker inspect -f '{{.State.Pid}}' <container id> でコンテナIDに対応するPIDを取得
-         * ps -p <pid> -o pid,comm,rss でRSSを取得
-    1の手法は遅い。
-    2の手法は早いが、Linuxでしか使えない。
-    3の手法の場合、ユーザ空間のプロセスのRSSを取得するため、全体のメモリ使用量を取得できない。
-    ref: https://unix.stackexchange.com/questions/686814/cgroup-and-process-memory-statistics-mismatch
-    '''
-
-    def __monitor_memory_usage_by_docker_stats(self) -> None:
-        while self._monitoring:
-            # docker statsコマンドを使ってコンテナのメモリ使用量を取得する
-            result = subprocess.run(
-                [
-                    "docker",
-                    "stats",
-                    "--no-stream",
-                    "--format",
-                    "{{.MemUsage}}",
-                    self.containerInfo.containerID,
-                ],
-                capture_output=True,
-                text=True,
-                check=False,
-            )
-
-            SANDBOX_LOGGER.debug(f"docker stats: {result.stdout}")
-
-            # result.stdout = "1.23GiB / 2.00GiB"といった形式でメモリ使用量が取得できる
-            # この値をパースしてmaxUsedMemoryを更新する
-            if result.returncode == 0:
-                mem_usage = result.stdout.strip()
-                used_memory = self.__parse_memory_usage_docker_stats(mem_usage)
-                if used_memory > self.maxUsedMemory:
-                    self.maxUsedMemory = used_memory
-                time.sleep(0.001)  # 1ms待つ
-
-    def __parse_memory_usage_docker_stats(self, mem_usage: str) -> int:
-        # "1.23 GiB / 2.00 GiB" -> 1.23 -> 1.23 * 1024 * 1024 * 1024
-        match = __MEM_USAGE_PATTERN.match(mem_usage)
-        if match:
-            # __MEM_USAGE_PATTERN.match("1.23 GiB / 2.00 GiB")
-            # match.group(1) = "1.23"
-            # match.group(2) = ".23"
-            # match.group(3) = "Gi"
-            value = float(match.group(1))
-            unit = match.group(3)
-            if unit == "Ki":
-                return int(value * 1024)
-            elif unit == "Mi":
-                return int(value * 1024 * 1024)
+    def exec_run(
+        self,
+        command: list[str],
+        user: str = "",
+        workDir: str = "/home/guest",
+        timeoutSec: float = 10.0,
+    ) -> tuple["ExecRunResult", Error]:
+        pass
+        # container.exec_run(...)でコマンドを実行する
+        # タイムアウト時刻を過ぎても終了しない場合はコンテナをkillする
+        try:
+            result = ExecRunResult()
+            error = Error("")
+            
+            def run_command():
+                exec_result = self._container.exec_run(
+                    cmd=command,
+                    user=user,
+                    demux=True
+                )
+                result.exitCode = exec_result.exit_code
+                stdout_data, stderr_data = exec_result.output
+                result.stdout = stdout_data.decode() if stdout_data else ""
+                result.stderr = stderr_data.decode() if stderr_data else ""
+                
+            # コマンド実行用スレッドを開始
+            thread = threading.Thread(target=run_command)
+            thread.start()
+            # 指定したタイムアウト時間だけ待機
+            thread.join(timeout=timeoutSec)
+            
+            # タイムアウトした場合はコンテナをkillする
+            if thread.is_alive():
+                self._container.kill()
+                error = Error(f"Command timed out after {timeoutSec} seconds. Container killed.")
+                thread.join()
             else:
-                assert unit == "Gi"
-                return int(value * 1024 * 1024 * 1024)
-        return 0
+                error = Error("")
+            
+            SANDBOX_LOGGER.debug(f"exec_run: {' '.join(command)}, err: {error}")
+            
+            # 
+            
+            return result, error
+        except APIError as e:
+            return Error(f"Failed to exec_run: {e}")
+        except Exception as e:
+            return Error(f"Failed to exec_run: {e}")
+        
 
-    def __monitor_memory_usage_by_cgroup(self) -> None:
-        # /sys/fs/cgroup/system.slice/docker-xxxxxx.scope/memory.current
-        # からメモリ使用量をバイト単位で取得する
-        while self._monitoring:
-            try:
-                if self._cgroup_path.exists():
-                    with self._cgroup_path.open("r") as f:
-                        mem_usage = int(f.read())
-                        if mem_usage > self.maxUsedMemory:
-                            self.maxUsedMemory = mem_usage
-            except FileNotFoundError:
-                # test_logger.info(f"Cgroup Path not exists: {cgroup_path}")
-                pass
-            except OSError:
-                # test_logger.info(f"Failed to read cgroup file: {cgroup_path}")
-                pass
-            time.sleep(0.001)
-
-
-class TaskResult(BaseModel):
+class ExecRunResult(BaseModel):
     exitCode: int = Field(default=-1)
     stdout: str = Field(default="")
     stderr: str = Field(default="")
     timeMS: int = Field(default=-1)
-    memoryByte: int = Field(default=-1)
-    TLE: bool = Field(default=True)  # 制限時間を超えたかどうか
 
 
-# タスクの実行情報
-@dataclass
-class TaskInfo:
-    imageName: str  # コンテナイメージ名
-    arguments: list[str] = field(default_factory=list)  # コンテナ内で実行するコマンド
-    timeoutSec: float = field(default=0.0)  # タイムアウト時間
-    user: str = field(default=f"{GUEST_UID}")
-    groups: list[str] = field(default_factory=lambda: [f"{GUEST_GID}"])
-    cpuset: list[int] | None = field(default=None)
-    memoryLimitMB: int = field(default=0)  # メモリ制限
-    stackLimitKB: int = field(default=0)  # リカージョンの深さを制限
-    pidsLimit: int = field(default=0)  # プロセス数の制限
-    enableNetwork: bool = field(default=False)
-    enableLoggingDriver: bool = field(default=True)
-    workDir: str = field(default="/home/guest")  # コンテナ内での作業ディレクトリ
-    cgroupParent: str = field(default=CGROUP_PARENT) # cgroupの親ディレクトリ
-    volumeMountInfoList: list[VolumeMountInfo] = field(
-        default_factory=list
-    )  # ボリュームのマウント情報
-    taskMonitor: TaskMonitor = field(
-        default_factory=lambda: TaskMonitor(ContainerInfo())
-    )
-
-    Stdin: str = ""  # 標準入力
-    Stdout: str = ""  # 標準出力
-    Stderr: str = ""  # 標準エラー出力
-
-    # Dockerコンテナの作成
-    def __create(self, client: docker.DockerClient) -> tuple[ContainerInfo, Error]:
-        # docker create ...
-        containerInfo = ContainerInfo()
-
-        # Dockerコンテナの作成
-        err = containerInfo._create(
-            client=client,
-            ImageName=self.imageName,
-            arguments=self.arguments,
-            cgroupParent=self.cgroupParent,
-            user=self.user,
-            groups=self.groups,
-            cpuset=self.cpuset,
-            memoryLimitMB=self.memoryLimitMB,
-            stackLimitKB=self.stackLimitKB,
-            pidsLimit=self.pidsLimit,
-            enableNetwork=self.enableNetwork,
-            enableLoggingDriver=self.enableLoggingDriver,
-            workDir=self.workDir,
-            volumeMountInfoList=self.volumeMountInfoList,
-        )
-
-        if err.message != "":
-            SANDBOX_LOGGER.debug(
-                f'containerID: {containerInfo.containerID}, err: "{err.message}"'
-            )
-            return ContainerInfo(), err
-
-        # モニターにコンテナ情報を設定
-        self.taskMonitor = TaskMonitor(
-            containerInfo=containerInfo
-        )
-
-        return containerInfo, Error("")
-
-    # docker start ... を実行して、コンテナを起動する。
-    # これにより、docker createで指定したコマンド(コンパイル、プログラムの実行等)が実行される。
-    def __start(self, containerInfo: ContainerInfo) -> tuple[TaskResult, Error]:
-        # self.timeout + 500msの制限時間を設定
-        timeout = 30.0  # デフォルトは30秒
-        if self.timeoutSec != 0.0:
-            timeout = self.timeoutSec + 0.5
-
-        # モニターを開始
-        self.taskMonitor.start()
-
-        # Dockerコンテナの起動
-        TLE = False
-        result = None
-        try:
-            # docker sdkのstartは、-i(interactive)オプションなどついていない
-            # subprocess.runで"docker start"コマンドを直接実行する
-            ProcessResult = subprocess.run(
-                args=["docker", "start", "-i", containerInfo.containerID],
-                capture_output=True,
-                text=True,
-                timeout=timeout,
-                input=self.Stdin,
-                check=False,
-            )
-            # 戻り値を検出
-            SANDBOX_LOGGER.debug(f"result: {ProcessResult}")
-        except subprocess.TimeoutExpired:
-            # タイムアウトした場合
-            # モニターを終了(これをしないとtaskMonitorのスレッドが終了しない)
-            self.taskMonitor.end()
-
-            # まだ実行中の場合があるので、docker kill...で停止させる。
-            try:
-                containerInfo._container.kill()
-            except APIError as e:
-                message = f"failed to stop docker: {e}"
-                SANDBOX_LOGGER.error(message)
-                SANDBOX_LOGGER.debug(message)
-                return TaskResult(
-                    TLE=True,
-                    timeMS=int(self.taskMonitor.get_elapsed_time_ms()),
-                    memoryByte=self.taskMonitor.get_used_memory_byte(),
-                ), Error(message)
-
-            result = containerInfo._container.wait()
-            exit_code: int = result["StatusCode"]
-            err_message: str = "" if "Error" not in result else result["Error"]["Message"]
-            if err_message != "":
-                return (
-                    TaskResult(
-                        TLE=True,
-                        timeMS=int(self.taskMonitor.get_elapsed_time_ms()),
-                        memoryByte=self.taskMonitor.get_used_memory_byte(),
-                    ),
-                    Error(err_message),
-                )
-            return TaskResult(
-                exitCode=exit_code,
-                TLE=True,
-                timeMS=int(self.taskMonitor.get_elapsed_time_ms()),
-                memoryByte=self.taskMonitor.get_used_memory_byte(),
-            ), Error("")
-
-        # モニターを終了
-        self.taskMonitor.end()
-
-        # 標準出力、標準エラー出力を取得
-        self.Stdout = containerInfo._container.logs(stdout=True, stderr=False).decode("utf-8")
-        self.Stderr = containerInfo._container.logs(stdout=False, stderr=True).decode("utf-8")
-
-        # タイムアウトしたかどうか
-        if (
-            self.timeoutSec != 0.0
-            and self.timeoutSec < self.taskMonitor.get_elapsed_time_ms() / 1000
-        ):
-            TLE = True
-
-        # 終了コードを取得
-        result = containerInfo._container.wait()
-        SANDBOX_LOGGER.debug(f"result: {result}")
-        exit_code = result["StatusCode"]
-        err_message = "" if "Error" not in result else result["Error"]["Message"]
-        if err_message != "":
-            return TaskResult(), Error(err_message)
-
-        return TaskResult(
-            exitCode=exit_code,
-            stdout=self.Stdout,
-            stderr=self.Stderr,
-            timeMS=int(self.taskMonitor.get_elapsed_time_ms()),
-            memoryByte=self.taskMonitor.get_used_memory_byte(),
-            TLE=TLE,
-        ), Error("")
-
-    def run(self, client: docker.DockerClient) -> tuple[TaskResult, Error]:
-        # コンテナ作成から起動までの処理を行う
-        # 途中で失敗したら、作成したコンテナの削除を行い、エラーを返す
-        containerInfo, err = self.__create(client=client)
-        SANDBOX_LOGGER.debug(
-            f'containerID: {containerInfo.containerID}, err: "{err.message}"'
-        )
-        if err.message != "":
-            # コンテナの作成に失敗した場合
-            return TaskResult(), err
-        SANDBOX_LOGGER.debug(f"containerID: {containerInfo.containerID}")
-
-        SANDBOX_LOGGER.debug("start container")
-        result, err = self.__start(containerInfo=containerInfo)
-
-        # コンテナの削除
-        err2 = containerInfo.remove()
-        if err2.message != "":
-            err.message += "\n" + err2.message
-
-        return result, err
+# watchdogに渡す設定
+class TaskInfo(BaseModel):
+    command: str
+    stdin: str
+    timeoutSec: int
+    memoryLimitMB: int
+    uid: int
+    gid: int
 
 
-def inspectExitCode(containerId: str) -> tuple[int, Error]:
-    args = ["inspect", "--format={{.State.ExitCode}}", containerId]
-
-    cmd = ["docker"] + args
-
-    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
-
-    SANDBOX_LOGGER.debug(f"inspect exit code: {result}")
-
-    err = ""
-    if result.returncode != 0:
-        err = f"Failed to inspect exit code: {result.stderr}"
-        return -1, Error(err)
-
-    return int(result.stdout), Error(err)
+class WatchDogResult(BaseModel):
+    exit_code: int
+    stdout: str
+    stderr: str
+    timeMS: int
+    memoryKB: int
+    TLE: bool
+    MLE: bool
+    
+    model_config = {
+        "from_attributes": True
+    }

--- a/src/sandbox/execute.py
+++ b/src/sandbox/execute.py
@@ -264,7 +264,7 @@ class ExecRunResult(BaseModel):
 class TaskInfo(BaseModel):
     command: str
     stdin: str
-    timeoutSec: int
+    timeoutMS: int
     memoryLimitMB: int
     uid: int
     gid: int

--- a/src/test_execute.py
+++ b/src/test_execute.py
@@ -2,16 +2,18 @@
 # $ cd src
 # $ pytest --log-cli-level=INFO test_execute.py
 import pytest
-import sandbox
-from sandbox.execute import TaskInfo
+from sandbox.execute import ContainerInfo
 from sandbox.execute import DockerVolume
 from sandbox.execute import VolumeMountInfo
+from sandbox.execute import TaskInfo, WatchDogResult
 import logging
 from datetime import timedelta
 from tempfile import TemporaryDirectory
 from pathlib import Path
 import time
 import docker
+from dotenv import load_dotenv
+import os
 
 from db.crud import *
 from db.database import SessionLocal
@@ -20,18 +22,33 @@ from db.database import SessionLocal
 logging.basicConfig(level=logging.INFO)
 test_logger = logging.getLogger(__name__)
 
+load_dotenv()
+GUEST_UID = os.getenv("GUEST_UID")
+GUEST_GID = os.getenv("GUEST_GID")
 
 # Dockerコンテナを起動して、Hello, World!を出力するテスト
 def test_RunHelloWorld():
-    task = TaskInfo(
+    client = docker.client.from_env()
+    container = ContainerInfo(
+        client=client,
         imageName="binary-runner",
-        arguments=["echo", "Hello, World!"],
-        timeoutSec=5.0,
+        arguments=["sleep", "3600"],
+        interactive=False,
+        user=GUEST_UID,
+        groups=[GUEST_GID],
+        workDir="/home/guest",
         memoryLimitMB=256,
-        cpuset=[0]
     )
+    
+    err = container.start()
+    assert err.message == ""
 
-    result, err = task.run(client=docker.from_env())
+    result, err = container.exec_run(
+        command=["echo", "Hello, World!"],
+        user=f"{GUEST_UID}:{GUEST_GID}",
+        workDir="/home/guest",
+        timeoutSec=5.0
+    )
 
     test_logger.info(result)
     test_logger.info(err)
@@ -43,19 +60,33 @@ def test_RunHelloWorld():
     assert result.stdout == "Hello, World!\n"
 
     assert result.stderr == ""
+    
+    err = container.remove()
+    assert err.message == ""
 
 
 # sandboxの戻り値をきちんとチェックできているか確かめるテスト
 def test_ExitCode():
-    task = TaskInfo(
+    client = docker.client.from_env()
+    container = ContainerInfo(
+        client=client,
         imageName="binary-runner",
-        arguments=["sh", "-c", "exit 123"],
-        timeoutSec=5.0,
+        arguments=["sleep", "3600"],
+        interactive=False,
+        user=GUEST_UID,
+        groups=[GUEST_GID],
+        workDir="/home/guest",
         memoryLimitMB=256,
-        cpuset=[0]
     )
-
-    result, err = task.run(client=docker.from_env())
+    err = container.start()
+    assert err.message == ""
+    
+    result, err = container.exec_run(
+        command=["sh", "-c", "exit 123"],
+        user=f"{GUEST_UID}:{GUEST_GID}",
+        workDir="/home/guest",
+        timeoutSec=5.0
+    )
 
     test_logger.info(result)
     test_logger.info(err)
@@ -64,32 +95,31 @@ def test_ExitCode():
     assert result.exitCode == 123
     assert result.stdout == ""
     assert result.stderr == ""
-
-
-# 標準入力をきちんと受け取れているか確かめるテスト
-def test_Stdin():
-    task = TaskInfo(
-        imageName="binary-runner",
-        arguments=["sh", "-c", 'read input; [ "$input" = "dummy" ]'],
-        Stdin="dummy",
-    )
-
-    result, err = task.run(client=docker.from_env())
-
-    test_logger.info(result)
-    test_logger.info(err)
-
+    
+    err = container.remove()
     assert err.message == ""
-    assert result.exitCode == 0
-    assert result.stdout == ""
-    assert result.stderr == ""
 
 
 # 標準出力をきちんとキャプチャできているか確かめるテスト
 def test_Stdout():
-    task = TaskInfo(imageName="binary-runner", arguments=["echo", "dummy"])
+    client = docker.client.from_env()
+    container = ContainerInfo(
+        client=client,
+        imageName="binary-runner",
+        arguments=["sleep", "3600"],
+        interactive=False,
+        user=GUEST_UID,
+        groups=[GUEST_GID],
+        workDir="/home/guest",
+        memoryLimitMB=256,
+    )    
 
-    result, err = task.run(client=docker.from_env())
+    result, err = container.exec_run(
+        command=["echo", "dummy"],
+        user=f"{GUEST_UID}:{GUEST_GID}",
+        workDir="/home/guest",
+        timeoutSec=5.0
+    )
 
     test_logger.info(result)
     test_logger.info(err)
@@ -98,13 +128,33 @@ def test_Stdout():
     assert result.exitCode == 0
     assert result.stdout == "dummy\n"
     assert result.stderr == ""
+    
+    err = container.remove()
+    assert err.message == ""
 
 
 # 標準エラー出力をちゃんとキャプチャできているか確かめるテスト
 def test_Stderr():
-    task = TaskInfo(imageName="binary-runner", arguments=["sh", "-c", "echo dummy >&2"])
-
-    result, err = task.run(client=docker.from_env())
+    client = docker.client.from_env()
+    container = ContainerInfo(
+        client=client,
+        imageName="binary-runner",
+        arguments=["sleep", "3600"],
+        interactive=False,
+        user=GUEST_UID,
+        groups=[GUEST_GID],
+        workDir="/home/guest",
+        memoryLimitMB=256,
+    )
+    err = container.start()
+    assert err.message == ""
+    
+    result, err = container.exec_run(
+        command=["sh", "-c", "echo dummy >&2"],
+        user=f"{GUEST_UID}:{GUEST_GID}",
+        workDir="/home/guest",
+        timeoutSec=5.0
+    )
 
     test_logger.info(result)
     test_logger.info(err)
@@ -113,13 +163,33 @@ def test_Stderr():
     assert result.exitCode == 0
     assert result.stdout == ""
     assert result.stderr == "dummy\n"
+    
+    err = container.remove()
+    assert err.message == ""
 
 
 # sleepした分ちゃんと実行時間が計測されているか確かめるテスト
 def test_SleepTime():
-    task = TaskInfo(imageName="binary-runner", arguments=["sleep", "3"], timeoutSec=5.0)
-
-    result, err = task.run(client=docker.from_env())
+    client = docker.client.from_env()
+    container = ContainerInfo(
+        client=client,
+        imageName="binary-runner",
+        arguments=["sleep", "3600"],
+        interactive=False,
+        user=GUEST_UID,
+        groups=[GUEST_GID],
+        workDir="/home/guest",
+        memoryLimitMB=256,
+    )
+    err = container.start()
+    assert err.message == ""
+    
+    result, err = container.exec_run(
+        command=["sleep", "3"],
+        user=f"{GUEST_UID}:{GUEST_GID}",
+        workDir="/home/guest",
+        timeoutSec=5.0
+    )
 
     test_logger.info(result)
     test_logger.info(err)
@@ -129,351 +199,279 @@ def test_SleepTime():
     assert result.stdout == ""
     assert result.stderr == ""
     assert result.timeMS >= 2000 and result.timeMS <= 5000
+    
+    err = container.remove()
+    assert err.message == ""
 
 
 # タイムアウトをきちんと検出できているか確かめるテスト
 def test_Timeout():
-    task = TaskInfo(imageName="binary-runner", arguments=["sleep", "100"], timeoutSec=3.0)
-
-    result, err = task.run(client=docker.from_env())
+    client = docker.client.from_env()
+    container = ContainerInfo(
+        client=client,
+        imageName="binary-runner",
+        arguments=["sleep", "3600"],
+        interactive=False,
+        user=GUEST_UID,
+        groups=[GUEST_GID],
+        workDir="/home/guest",
+        memoryLimitMB=256,
+    )
+    
+    result, err = container.exec_run(
+        command=["sleep", "100"],
+        user=f"{GUEST_UID}:{GUEST_GID}",
+        workDir="/home/guest",
+        timeoutSec=3.0
+    )
 
     test_logger.info(result)
     test_logger.info(err)
 
     assert err.message == ""
-    assert result.TLE == True
-
-
-# ファイルをDockerボリュームにコピーするテスト
-def test_CopyFileFromClientToVolume():
-    # ファイル転送先のボリュームの作成
-    client = docker.from_env()
-    volume, err = DockerVolume.create(client=client)
-
-    assert err.message == ""
-
-    # tempdir にファイルを作成
-    with TemporaryDirectory() as tempdir:
-        with open(Path(tempdir) / "test.txt", "w") as f:
-            f.write("Hello, World!")
-
-        # ファイルをボリュームにコピー
-        err = volume.copyFile(client=client, srcPathOnClient=Path(tempdir) / "test.txt", dstDirOnVolume=Path("./"))
-        assert err.message == ""
-
-    # ファイルがコピーされたことを確認
-    task = TaskInfo(
-        imageName="binary-runner",
-        arguments=["cat", "test.txt"],
-        workDir="/home/guest/",
-        volumeMountInfoList=[VolumeMountInfo(path="/home/guest/", volume=volume)],
+    assert result.timeMS >= 2000 and result.timeMS <= 5000
+    
+    # WatchDogを用いて、タイムアウトを検出できるか確かめる
+    task_info = TaskInfo(
+        command=["sleep", "100"],
+        stdin="",
+        timeoutSec=3.0,
+        memoryLimitMB=256,
+        uid=int(GUEST_UID),
+        gid=int(GUEST_GID),
     )
 
-    result, err = task.run(client=client)
+    with TemporaryDirectory() as tmpdir:
+        with open(Path(tmpdir) / "task.json", "w") as f:
+            f.write(task_info.model_dump_json())
 
-    test_logger.info(result)
-
-    assert err.message == ""
-
-    assert result.exitCode == 0
-
-    assert result.stdout == "Hello, World!"
-
-    assert result.stderr == ""
-
-    err = volume.remove()
-
-    assert err.message == ""
-
-
-# 複数のファイルをDockerボリュームにコピーするテスト
-def test_CopyFilesFromClientToVolume():
-    # ファイル転送先のボリュームの作成
-    client = docker.from_env()
-    volume, err = DockerVolume.create(client=client)
-
-    assert err.message == ""
-
-    # tempdir にファイルを作成
-    with TemporaryDirectory() as tempdir:
-        with open(Path(tempdir) / "test1.txt", "w") as f:
-            f.write("Hello, World!")
-
-        with open(Path(tempdir) / "test2.txt", "w") as f:
-            f.write("Goodbye, World!")
-
-        # ファイルをボリュームにコピー
-        err = volume.copyFiles(
-            client=client,
-            srcPathsOnClient=[
-                Path(tempdir) / "test1.txt",
-                Path(tempdir) / "test2.txt",
-            ],
-            dstDirOnVolume=Path("./"),
+        err = container.copyFile(srcInHost=Path(tmpdir) / "task.json", dstInContainer=Path("/home/guest"))
+        assert err.message == ""
+        
+        res, err = container.exec_run(
+            command=["chown", "root:root", "/home/guest/task.json"],
+            user="root",
+            workDir="/home/guest",
+            timeoutSec=2.0
         )
         assert err.message == ""
-    # ファイルがコピーされたことを確認
-    task = TaskInfo(
-        imageName="binary-runner",
-        arguments=["cat", "test1.txt", "test2.txt"],
-        workDir="/home/guest/",
-        volumeMountInfoList=[VolumeMountInfo(path="/home/guest/", volume=volume)],
-    )
-
-    result, err = task.run(client=client)
-
-    test_logger.info(result)
-
-    assert err.message == ""
-
-    assert result.exitCode == 0
-
-    assert result.stdout == "Hello, World!Goodbye, World!"
-
-    assert result.stderr == ""
-
-    err = volume.remove()
-
-    assert err.message == ""
-
-
-# Dockerボリュームにある複数のファイルを削除するテスト
-def test_RemoveFilesInVolume():
-    # ファイル転送先のボリュームの作成
-    client = docker.from_env()
-    volume, err = DockerVolume.create(client=client)
-
-    assert err.message == ""
-
-    # tempdir にファイルを作成
-    with TemporaryDirectory() as tempdir:
-        with open(Path(tempdir) / "test1.txt", "w") as f:
-            f.write("Hello, World!")
-
-        with open(Path(tempdir) / "test2.txt", "w") as f:
-            f.write("Goodbye, World!")
-
-        # ファイルをボリュームにコピー
-        err = volume.copyFiles(
-            client=client,
-            srcPathsOnClient=[
-                Path(tempdir) / "test1.txt",
-                Path(tempdir) / "test2.txt",
-            ],
-            dstDirOnVolume=Path("./"),
+        
+        res, err = container.exec_run(
+            command=["chmod", "600", "/home/guest/task.json"],
+            user="root",
+            workDir="/home/guest",
+            timeoutSec=2.0
         )
         assert err.message == ""
 
-    # ファイルがコピーされたことを確認
-    task = TaskInfo(
-        imageName="binary-runner",
-        arguments=["ls"],
-        workDir="/home/guest/",
-        volumeMountInfoList=[VolumeMountInfo(path="/home/guest/", volume=volume)],
-    )
-
-    result, err = task.run(client=client)
-
-    test_logger.info(result)
-
-    assert err.message == ""
-
-    assert result.exitCode == 0
-
-    assert result.stdout == "test1.txt\ntest2.txt\n"
-
-    assert result.stderr == ""
-
-    # ファイルを削除
-    err = volume.removeFiles(client=client, filePathsInVolume=[Path("test1.txt"), Path("test2.txt")])
-    assert err.message == ""
-
-    # ファイルが削除されたことを確認
-    task = TaskInfo(
-        imageName="binary-runner",
-        arguments=["ls"],
-        workDir="/home/guest/",
-        volumeMountInfoList=[VolumeMountInfo(path="/home/guest/", volume=volume)],
-    )
-
-    result, err = task.run(client=client)
-
-    test_logger.info(result)
-
-    assert err.message == ""
-
-    assert result.exitCode == 0
-
-    assert result.stdout == ""
-
-    assert result.stderr == ""
-
-    err = volume.remove()
-
-    test_logger.info(err)
-
-    assert err.message == ""
-
-
-# ボリュームのクローンができているかチェック
-def test_CloneVolume():
-    # 一時ディレクトリを作成
-    with TemporaryDirectory() as temp_dir:
-        # テストファイルを作成
-        file1_path = Path(temp_dir) / "file1.txt"
-        file2_path = Path(temp_dir) / "file2.txt"
-        with open(file1_path, "w") as f1, open(file2_path, "w") as f2:
-            f1.write("Content of file1")
-            f2.write("Content of file2")
-
-        # 元のボリュームを作成
-        client = docker.from_env()
-        original_volume, err = DockerVolume.create(client=client)
-        assert err.message == ""
-
-        # テストファイルを元のボリュームにコピー
-        err = original_volume.copyFile(client=client, srcPathOnClient=Path(file1_path))
-        assert err.message == ""
-        err = original_volume.copyFile(client=client, srcPathOnClient=Path(file2_path))
-        assert err.message == ""
-
-        # ボリュームをクローン
-        cloned_volume, err = original_volume.clone(client=client)
-        assert err.message == ""
-
-        # クローンされたボリュームの内容を確認
-        task = TaskInfo(
-            imageName="binary-runner",
-            arguments=["ls"],
-            workDir="/home/guest/",
-            volumeMountInfoList=[VolumeMountInfo(path="/home/guest/", volume=cloned_volume)],
+        res, err = container.exec_run(
+            command=["./watchdog", "task.json"],
+            user="root",
+            workDir="/home/guest",
+            timeoutSec=8.0
         )
+        assert err.message == ""
+        
+        test_logger.info(res)
+        
+        watchdog_result = WatchDogResult.model_validate_json(res.stdout)
+        assert watchdog_result.TLE == True
 
-        result, err = task.run(client=client)
-        assert err.message == ""
-        assert result.exitCode == 0
-        assert "file1.txt" in result.stdout
-        assert "file2.txt" in result.stdout
-
-        # クリーンアップ
-        err = original_volume.remove()
-        assert err.message == ""
-        err = cloned_volume.remove()
-        assert err.message == ""
+    err = container.remove()
+    assert err.message == ""
 
 # メモリ制限を検出できるかチェック
 def test_MemoryLimit():
-    task = TaskInfo(
+    client = docker.client.from_env()
+    container = ContainerInfo(
+        client=client,
         imageName="binary-runner",
-        arguments=["dd", "if=/dev/zero", "of=/dev/null", "bs=800M"],
-        timeoutSec=3.0,
+        arguments=["sleep", "3600"],
+        interactive=False,
+        user=GUEST_UID,
+        groups=[GUEST_GID],
+        workDir="/home/guest",
         memoryLimitMB=500,
     )
-
-    result, err = task.run(client=docker.from_env())
-
+    err = container.start()
     assert err.message == ""
 
-    test_logger.info(result)
+    result, err = container.exec_run(
+        command=["dd", "if=/dev/zero", "of=/dev/null", "bs=800M"],
+        user="root",
+        workDir="/home/guest",
+        timeoutSec=3.0,
+    )
 
+    test_logger.info(result)
+    test_logger.info(err)
+    
     assert result.exitCode != 0
-    # assert result.TLE == False
-    assert abs(result.memoryByte - 500 * 1024 * 1024) < 1024 * 1024
+    
+    # WatchDogを用いて、メモリ制限を検出できるか確かめる
+    task_info = TaskInfo(
+        command=["dd", "if=/dev/zero", "of=/dev/null", "bs=800M"],
+        stdin="",
+        timeoutSec=3.0,
+        memoryLimitMB=500,
+        uid=int(GUEST_UID),
+        gid=int(GUEST_GID),
+    )
+    
+    with TemporaryDirectory() as tmpdir:
+        with open(Path(tmpdir) / "task.json", "w") as f:
+            f.write(task_info.model_dump_json())
+        
+        err = container.copyFile(srcInHost=Path(tmpdir) / "task.json", dstInContainer=Path("/home/guest"))
+        assert err.message == ""
+        
+        res, err = container.exec_run(
+            command=["chown", "root:root", "/home/guest/task.json"],
+            user="root",
+            workDir="/home/guest",
+            timeoutSec=2.0
+        )
+        assert err.message == ""
+        
+        res, err = container.exec_run(
+            command=["chmod", "600", "/home/guest/task.json"],
+            user="root",
+            workDir="/home/guest",
+            timeoutSec=2.0
+        )
+        assert err.message == ""
+        
+        res, err = container.exec_run(
+            command=["./watchdog", "task.json"],
+            user="root",
+            workDir="/home/guest",
+            timeoutSec=8.0
+        )
+        assert err.message == ""
+        
+        test_logger.info(res)
+        
+        watchdog_result = WatchDogResult.model_validate_json(res.stdout)
+        assert watchdog_result.MLE == True
+    
+    err = container.remove()
+    assert err.message == ""
 
 
 # ネットワーク制限をできているかチェック
 def test_NetworkDisable():
-    task = TaskInfo(
+    client = docker.client.from_env()
+    
+    container = ContainerInfo(
+        client=client,
         imageName="ibmcom/ping",
-        arguments=["ping", "-c", "5", "google.com"],
+        arguments=["sleep", "3600"],
         enableNetwork=None,
     )
+    
+    err = container.start()
+    assert err.message == ""
+    
+    res, err = container.exec_run(
+        command=["ping", "-c", "5", "google.com"],
+        user="root",
+        workDir="/home/guest",
+        timeoutSec=10.0
+    )
 
-    result, err = task.run(client=docker.from_env())
+    test_logger.info(res)
+    test_logger.info(err)
 
     assert err.message == ""
 
-    test_logger.info(result)
-
-    assert result.exitCode != 0
-    assert result.TLE == False
-    assert result.stdout == ""
+    assert res.exitCode != 0
+    assert res.stdout == ""
+    
+    err = container.remove()
+    assert err.message == ""
 
 
 # フォークボムなどの攻撃に対処できるように、プロセス数制限ができているかチェック
 def test_ForkBomb():
     client = docker.from_env()
-    volume, err = DockerVolume.create(client=client)
-
-    assert err.message == ""
-
-    err = volume.copyFile(client=client, srcPathOnClient=Path("sources/fork_bomb.sh"))
-
-    assert err.message == ""
-
-    task = TaskInfo(
+    container = ContainerInfo(
+        client=client,
         imageName="binary-runner",
-        arguments=["./fork_bomb.sh"],
-        workDir="/home/guest/",
-        volumeMountInfoList=[VolumeMountInfo(path="/home/guest/", volume=volume)],
-        timeoutSec=3.0,
-        pidsLimit=10,
+        arguments=["sleep", "3600"],
+        pidsLimit=20,
+        user=GUEST_UID,
+        groups=[GUEST_GID],
+        workDir="/home/guest",
+    )
+    
+    err = container.start()
+    assert err.message == ""
+
+    err = container.copyFile(srcInHost=Path("sources/fork_bomb.sh"), dstInContainer=Path("/home/guest"))
+
+    assert err.message == ""
+
+    res, err = container.exec_run(
+        command=["./fork_bomb.sh"],
+        user=GUEST_UID,
+        workDir="/home/guest",
+        timeoutSec=10.0
     )
 
-    result, err = task.run(client=client)
-
-    test_logger.info(result)
+    test_logger.info(res)
     test_logger.info(err)
 
-    err = volume.remove()
-
+    assert err.message == ""
+    assert res.exitCode != 0
+    
+    err = container.remove()
     assert err.message == ""
 
 
 # スタックメモリの制限ができているかチェック
 def test_UseManyStack():
     client = docker.from_env()
-    volume, err = DockerVolume.create(client=client)
-
-    assert err.message == ""
-
-    err = volume.copyFile(client=client, srcPathOnClient=Path("sources/use_many_stack.c"))
-
-    assert err.message == ""
-
-    task = TaskInfo(
+    container = ContainerInfo(
+        client=client,
         imageName="checker-lang-gcc",
-        arguments=["gcc", "use_many_stack.c"],
-        workDir="/home/guest/",
-        volumeMountInfoList=[VolumeMountInfo(path="/home/guest/", volume=volume)],
-    )
-
-    result, err = task.run(client=client)
-
-    test_logger.info(result)
-    test_logger.info(err)
-
-    assert err.message == ""
-    assert result.exitCode == 0
-
-    task = TaskInfo(
-        imageName="binary-runner",
-        arguments=["./a.out"],
-        workDir="/home/guest/",
-        volumeMountInfoList=[VolumeMountInfo(path="/home/guest/", volume=volume)],
+        arguments=["sleep", "3600"],
+        workDir="/home/guest",
         stackLimitKB=10240,
         memoryLimitMB=256,
     )
+    
+    err = container.start()
+    assert err.message == ""
 
-    result, err = task.run(client=client)
+    err = container.copyFile(srcInHost=Path("sources/use_many_stack.c"), dstInContainer=Path("/home/guest"))
+    assert err.message == ""
+    
+    res, err = container.exec_run(
+        command=["gcc", "use_many_stack.c"],
+        user=f"{GUEST_UID}:{GUEST_GID}",
+        workDir="/home/guest",
+        timeoutSec=10.0,
+    )
 
-    test_logger.info(result)
+    test_logger.info(res)
+    test_logger.info(err)
+    assert err.message == ""
+    assert res.exitCode == 0
+    
+    res, err = container.exec_run(
+        command=["./a.out"],
+        user=f"{GUEST_UID}:{GUEST_GID}",
+        workDir="/home/guest",
+        timeoutSec=10.0,
+    )
+
+    test_logger.info(res)
     test_logger.info(err)
 
-    assert result.exitCode != 0
+    assert err.message == ""
+    assert res.exitCode != 0
 
-    err = volume.remove()
-
+    err = container.remove()
     assert err.message == ""
 
 

--- a/src/test_execute.py
+++ b/src/test_execute.py
@@ -280,7 +280,7 @@ def test_Timeout():
     task_info = TaskInfo(
         command="sleep 100",
         stdin="",
-        timeoutSec=3.0,
+        timeoutMS=3000,
         memoryLimitMB=256,
         uid=int(GUEST_UID),
         gid=int(GUEST_GID),
@@ -361,7 +361,7 @@ def test_MemoryLimit():
     task_info = TaskInfo(
         command="dd if=/dev/zero of=/dev/null bs=800M",
         stdin="",
-        timeoutSec=3.0,
+        timeoutMS=3000,
         memoryLimitMB=300,
         uid=int(GUEST_UID),
         gid=int(GUEST_GID),


### PR DESCRIPTION
# ジャッジの実行プロセス
## ソースコードが入っているボリュームの作成
サンドボックスコンテナにattachする。
## コンパイルの実行
* `gcc`が使えるコンテナの立ち上げ(`checker-lang-gcc`)
* コンパイルを実行
## ジャッジの実行
* `perl`と`valgrind`がインストールされているsandboxコンテナの立ち上げ(`binary-runner`)
* コンパイルされたプログラムの実行
    * `watchdog`というプログラムをroot権限で動作させる。`watchdog`にはコマンド、制限時間、最大メモリ、ゲストユーザのuid:gidを伝える。
    * `watchdog`がゲストユーザでサブプロセスをspawn、時間とメモリを監視する
    * リソース制限を超えたら、そのサブプロセスとその子孫まで全部強制終了させる
    * ホストの方でもタイムアウト時間を設定しており、`watchdog`がその時間までに終了しなかったらコンテナごと強制終了